### PR TITLE
70 unique date ids for meetings

### DIFF
--- a/README.md
+++ b/README.md
@@ -29,7 +29,7 @@ The Ecologistics Web Scraper team consists of {#} Cal Poly students. Over the co
 - [James Torres](www.linkedin.com/in/jameskt) - Software Developer
 - [Isha Varrier](https://www.linkedin.com/in/isha-varrier-19a35a1b5/) - Software Developer
 - [Eeshan Walia](https://www.linkedin.com/in/eeshan-walia-ab8a501b6/) - Software Developer
-- [Sharan Krishna] (https://www.linkedin.com/in/sharankrishna14/) - Software Developer
+- [Sharan Krishna](https://www.linkedin.com/in/sharankrishna14/) - Software Developer
 - [Wesley Tam](https://www.linkedin.com/in/wesleyltam/) - Software Developer
 - [Sophia Peckner](https://www.linkedin.com/in/sophia-peckner-2a613a1b0/) - Software Developer
 

--- a/backend/api/utils/slo_county/scrape_hearings.py
+++ b/backend/api/utils/slo_county/scrape_hearings.py
@@ -35,10 +35,9 @@ def scrape_hearings():
                     id = date_to_unix(date_string)
                     detail_ids.append(id)
 
-        # Print the extracted links
+        # Print the extracted links and associated meeting ids
         for i, link in enumerate(detail_links):
-            print(link)
-            print(detail_ids[i])
+            print(link, detail_ids[i])
 
     else:
         print("Table not found or empty.")
@@ -54,6 +53,24 @@ def date_to_unix(date: str) -> int:
     date_object = datetime.strptime(date, "%B %d, %Y - %I:%M %p")
     unix_time = time.mktime(date_object.timetuple())
     return int(unix_time)
+
+
+def in_db(id: int) -> bool:
+    '''
+    Given a meeting id, return if the meeting is in the database
+    '''
+    # connect to mongoDB database
+    # loop through all meetings in the mongoDB database
+    #   if the meeting id is stored
+    #       check for equality
+    #   if the date is stored but not the id
+    #       convert date to unixtime/id
+    #       check for equality
+    #   if the link is stored but neither the date nor id are
+    #       scrape the link and grab the date of the meeting
+    #       convert date to unixtime/id
+    #       check for equality
+    pass
 
 
 scrape_hearings()

--- a/backend/api/utils/slo_county/scrape_hearings.py
+++ b/backend/api/utils/slo_county/scrape_hearings.py
@@ -30,6 +30,7 @@ def scrape_hearings():
                     detail_links.append(a_tag['href'])
 
                     # Generate unique ID based on time of event
+                    # Assumes 2 meetings cannot have the same date and time
                     date = event.find('td', class_='listItem', headers='Date')
                     date_string = date.get_text(strip=True)
                     id = date_to_unix(date_string)

--- a/backend/api/utils/slo_county/scrape_hearings.py
+++ b/backend/api/utils/slo_county/scrape_hearings.py
@@ -1,5 +1,7 @@
 import requests
+import time
 from bs4 import BeautifulSoup
+from datetime import datetime
 
 
 def scrape_hearings():
@@ -7,29 +9,51 @@ def scrape_hearings():
     response = requests.get(url)
 
     soup = BeautifulSoup(response.content, "html.parser")
-    table = soup.find("table", class_="listingTable")
+    upcoming_events_table = soup.find("table", class_="listingTable")
     
     detail_links = []
+    detail_ids = []
 
     # Check if the table is found
-    if table:
-        # Find all <a> tags within <td> tags with class "listItem" and headers "ItemDocumentsUpcoming"
-        item_detail_links = table.find_all(
-            'td', class_='listItem', headers='ItemDocumentsUpcoming')
+    if upcoming_events_table:
+        # Find all <tr> tags within the upcoming events table
+        events = upcoming_events_table.find_all('tr', class_='listingRow')
 
-        # Extract the href attribute from each <a> tag
-        for link in item_detail_links:
-            a_tag = link.find('a')
-            if a_tag:
-                detail_links.append(a_tag['href'])
+        for event in events:
+            link = event.find(
+                'td', class_='listItem', headers='ItemDocumentsUpcoming')
+
+            if link:
+                # Extract the href attribute from each <a> tag
+                a_tag = link.find('a')
+                if a_tag:
+                    detail_links.append(a_tag['href'])
+
+                    # Generate unique ID based on time of event
+                    date = event.find('td', class_='listItem', headers='Date')
+                    date_string = date.get_text(strip=True)
+                    id = date_to_unix(date_string)
+                    detail_ids.append(id)
 
         # Print the extracted links
-        for link in detail_links:
+        for i, link in enumerate(detail_links):
             print(link)
+            print(detail_ids[i])
+
     else:
         print("Table not found or empty.")
 
     return detail_links
+
+
+def date_to_unix(date: str) -> int:
+    '''
+    Given a date string of format "January 1, 2024 - 9:00 AM",
+    return its unix timestamp
+    '''
+    date_object = datetime.strptime(date, "%B %d, %Y - %I:%M %p")
+    unix_time = time.mktime(date_object.timetuple())
+    return int(unix_time)
 
 
 scrape_hearings()


### PR DESCRIPTION
## Developer: Wesley Tam

Closes #70 

### Pull Request Summary

- Add unique ID generation for web-scraped meetings
- Add pseudocode for checking if a meeting ID is already in the database

### Modifications

- slo_county/scrape_hearings.py: added above, refactored existing code (renamed variables, etc.)

### Testing Considerations

Run the python file and confirm that an ID is generated for every meeting with a link and that it is the UNIX timestamp of the meeting time

### Pull Request Checklist

- [ ] Code is neat, readable, and works
- [ ] Comments are appropriate
- [ ] The commit messages follows our [guidelines](https://h4i.notion.site/Conventional-Commits-593452ad1179489399ad3bd696ef772a)
- [ ] The developer name is specified
- [ ] The summary is completed
- [ ] Assign reviewers

### Screenshots/Screencast
