### PR TITLE
feat: protect login and signup page when signed in

### DIFF
--- a/frontend/src/app/(auth)/login/page.tsx
+++ b/frontend/src/app/(auth)/login/page.tsx
@@ -11,7 +11,7 @@ import {
 import { Input } from "@/components/ui/input";
 import { Label } from "@/components/ui/label";
 import Link from "next/link";
-import { signIn } from "next-auth/react";
+import { useSession, signIn } from "next-auth/react";
 import { useRouter } from "next/navigation";
 import { ExclamationTriangleIcon } from "@radix-ui/react-icons";
 import { Alert, AlertDescription, AlertTitle } from "@/components/ui/alert";
@@ -22,8 +22,12 @@ export default function LoginPage() {
   const [passwordShown, setPasswordShown] = useState(false);
   const router = useRouter();
   const [errorMessage, setErrorMessage] = useState("");
+  const { data: session } = useSession();
 
-  // const router = useRouter();
+  // If signed in, reroute to home page
+  if (session?.user?.email) {
+    router.push("/");
+  }
 
   const togglePasswordShown = () => {
     setPasswordShown(!passwordShown);

--- a/frontend/src/app/(auth)/signup/page.tsx
+++ b/frontend/src/app/(auth)/signup/page.tsx
@@ -14,6 +14,7 @@ import Link from "next/link";
 import { useRouter } from "next/navigation";
 import { ExclamationTriangleIcon } from "@radix-ui/react-icons";
 import { Alert, AlertDescription, AlertTitle } from "@/components/ui/alert";
+import { useSession } from "next-auth/react";
 
 export default function SignUpPage() {
   const [email, setEmail] = useState("");
@@ -22,8 +23,13 @@ export default function SignUpPage() {
   const [passwordShown, setPasswordShown] = useState(false);
   const [confirmpasswordShown, setConfirmpasswordShown] = useState(false);
   const [errorMessage, setErrorMessage] = useState("");
-
   const router = useRouter();
+  const { data: session } = useSession();
+
+  // If signed in, reroute to home page
+  if (session?.user?.email) {
+    router.push("/");
+  }
 
   const togglePasswordShown = () => {
     setPasswordShown(!passwordShown);


### PR DESCRIPTION
## Developer: Wesley Tam

Closes #81 

### Pull Request Summary

Protects the login and signup pages when the user is signed in.

### Modifications

login/page.tsx + signup/page.tsx: Add a check to see if the user is signed in, redirects to the home page if so.

### Testing Considerations

- While logged in, try to access the login and signup page
- While not logged in, try to login and/or signup to ensure regular flow still works

### Pull Request Checklist

- [ ] Code is neat, readable, and works
- [ ] Comments are appropriate
- [ ] The commit messages follows our [guidelines](https://h4i.notion.site/Conventional-Commits-593452ad1179489399ad3bd696ef772a)
- [ ] The developer name is specified
- [ ] The summary is completed
- [ ] Assign reviewers

### Screenshots/Screencast
