### PR TITLE
80, 96, 102 web scraper metadata

### DIFF
--- a/backend/api/chalicelib/routes/slo_county.py
+++ b/backend/api/chalicelib/routes/slo_county.py
@@ -4,6 +4,8 @@ from chalice import Blueprint
 import sys
 from pathlib import Path
 
+from chalicelib.utils.slo_county.update_metadata import update_metadata
+
 # in the api directory run
 # >> python3 routes/slo_county.py
 # this is so that we can import local modules by adding
@@ -52,6 +54,7 @@ def get_hearings():
             )
 
     add_projects_to_mongo(projects)
+    update_metadata(len(hearings), projects)
 
     # sch_projects = scrape_sch()
     # To do: cross-reference projects in sch and fill in missing data

--- a/backend/api/chalicelib/utils/slo_county/update_metadata.py
+++ b/backend/api/chalicelib/utils/slo_county/update_metadata.py
@@ -1,0 +1,51 @@
+from typing import List
+from chalicelib.models.project import Project
+from chalicelib.mongodb import get_mongo_client
+from datetime import datetime
+
+PROJECTS_DATABASE = "test"
+PROJECTS_COLLECTION = "projects"
+METADATA_DATABASE = "test"
+METADATA_COLLECTION = "scrapermetadatas"
+
+
+def update_metadata(hearingsScraped: int, scrapedProjects: List[Project]):
+    newProjects = 0
+    newSCHProjects = 0
+
+    client = get_mongo_client()
+    if client:
+        try:
+            metadataCollection = client[METADATA_DATABASE][METADATA_COLLECTION]
+            projectsCollection = client[PROJECTS_DATABASE][PROJECTS_COLLECTION]
+        except Exception:
+            print("A collection was not found")
+            return
+
+        # find new projects by county file num and date
+        for project in scrapedProjects:
+            fileNum = project.county_file_number
+            hearingDate = project.hearing_date
+            projectMatch = projectsCollection.find_one({'$and': [
+                {'county_file_number': fileNum},
+                {'hearing_date': hearingDate}
+                ]})
+
+            if projectMatch is None:                    # newely scraped
+                newProjects += 1
+                if project.sch_number is not None:      # contains SCH num
+                    newSCHProjects += 1
+
+        # update the metadata document in collection
+        # date uses iso format for conversion between
+        # python datetime to TS Date objects
+        metadataCollection.update_one({}, {
+            '$set': {'lastRan': datetime.now().isoformat()},
+            '$inc': {
+                'totalHearingsScraped': hearingsScraped,
+                'totalProjectsScraped': newProjects,
+                'totalSCHProjectsScraped': newSCHProjects
+            }
+        },
+            upsert=True
+        )

--- a/backend/api/chalicelib/utils/slo_county/update_metadata.py
+++ b/backend/api/chalicelib/utils/slo_county/update_metadata.py
@@ -45,12 +45,7 @@ def update_metadata(hearingsScraped: int, scrapedProjects: List[Project]):
                 'totalHearingsScraped': hearingsScraped,
                 'totalProjectsScraped': newProjects,
                 'totalSCHProjectsScraped': newSCHProjects
-<<<<<<< HEAD:backend/api/chalicelib/utils/slo_county/update_metadata.py
-            }
-        },
-=======
                 }
             },
->>>>>>> 954736c (chore: formatting):backend/api/utils/slo_county/update_metadata.py
             upsert=True
         )

--- a/backend/api/chalicelib/utils/slo_county/update_metadata.py
+++ b/backend/api/chalicelib/utils/slo_county/update_metadata.py
@@ -45,7 +45,12 @@ def update_metadata(hearingsScraped: int, scrapedProjects: List[Project]):
                 'totalHearingsScraped': hearingsScraped,
                 'totalProjectsScraped': newProjects,
                 'totalSCHProjectsScraped': newSCHProjects
+<<<<<<< HEAD:backend/api/chalicelib/utils/slo_county/update_metadata.py
             }
         },
+=======
+                }
+            },
+>>>>>>> 954736c (chore: formatting):backend/api/utils/slo_county/update_metadata.py
             upsert=True
         )

--- a/frontend/package-lock.json
+++ b/frontend/package-lock.json
@@ -6485,6 +6485,126 @@
       "funding": {
         "url": "https://github.com/sponsors/colinhacks"
       }
+    },
+    "node_modules/@next/swc-darwin-x64": {
+      "version": "14.1.1",
+      "resolved": "https://registry.npmjs.org/@next/swc-darwin-x64/-/swc-darwin-x64-14.1.1.tgz",
+      "integrity": "sha512-KCQmBL0CmFmN8D64FHIZVD9I4ugQsDBBEJKiblXGgwn7wBCSe8N4Dx47sdzl4JAg39IkSN5NNrr8AniXLMb3aw==",
+      "cpu": [
+        "x64"
+      ],
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "engines": {
+        "node": ">= 10"
+      }
+    },
+    "node_modules/@next/swc-linux-arm64-gnu": {
+      "version": "14.1.1",
+      "resolved": "https://registry.npmjs.org/@next/swc-linux-arm64-gnu/-/swc-linux-arm64-gnu-14.1.1.tgz",
+      "integrity": "sha512-YDQfbWyW0JMKhJf/T4eyFr4b3tceTorQ5w2n7I0mNVTFOvu6CGEzfwT3RSAQGTi/FFMTFcuspPec/7dFHuP7Eg==",
+      "cpu": [
+        "arm64"
+      ],
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">= 10"
+      }
+    },
+    "node_modules/@next/swc-linux-arm64-musl": {
+      "version": "14.1.1",
+      "resolved": "https://registry.npmjs.org/@next/swc-linux-arm64-musl/-/swc-linux-arm64-musl-14.1.1.tgz",
+      "integrity": "sha512-fiuN/OG6sNGRN/bRFxRvV5LyzLB8gaL8cbDH5o3mEiVwfcMzyE5T//ilMmaTrnA8HLMS6hoz4cHOu6Qcp9vxgQ==",
+      "cpu": [
+        "arm64"
+      ],
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">= 10"
+      }
+    },
+    "node_modules/@next/swc-linux-x64-gnu": {
+      "version": "14.1.1",
+      "resolved": "https://registry.npmjs.org/@next/swc-linux-x64-gnu/-/swc-linux-x64-gnu-14.1.1.tgz",
+      "integrity": "sha512-rv6AAdEXoezjbdfp3ouMuVqeLjE1Bin0AuE6qxE6V9g3Giz5/R3xpocHoAi7CufRR+lnkuUjRBn05SYJ83oKNQ==",
+      "cpu": [
+        "x64"
+      ],
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">= 10"
+      }
+    },
+    "node_modules/@next/swc-linux-x64-musl": {
+      "version": "14.1.1",
+      "resolved": "https://registry.npmjs.org/@next/swc-linux-x64-musl/-/swc-linux-x64-musl-14.1.1.tgz",
+      "integrity": "sha512-YAZLGsaNeChSrpz/G7MxO3TIBLaMN8QWMr3X8bt6rCvKovwU7GqQlDu99WdvF33kI8ZahvcdbFsy4jAFzFX7og==",
+      "cpu": [
+        "x64"
+      ],
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">= 10"
+      }
+    },
+    "node_modules/@next/swc-win32-arm64-msvc": {
+      "version": "14.1.1",
+      "resolved": "https://registry.npmjs.org/@next/swc-win32-arm64-msvc/-/swc-win32-arm64-msvc-14.1.1.tgz",
+      "integrity": "sha512-1L4mUYPBMvVDMZg1inUYyPvFSduot0g73hgfD9CODgbr4xiTYe0VOMTZzaRqYJYBA9mana0x4eaAaypmWo1r5A==",
+      "cpu": [
+        "arm64"
+      ],
+      "optional": true,
+      "os": [
+        "win32"
+      ],
+      "engines": {
+        "node": ">= 10"
+      }
+    },
+    "node_modules/@next/swc-win32-ia32-msvc": {
+      "version": "14.1.1",
+      "resolved": "https://registry.npmjs.org/@next/swc-win32-ia32-msvc/-/swc-win32-ia32-msvc-14.1.1.tgz",
+      "integrity": "sha512-jvIE9tsuj9vpbbXlR5YxrghRfMuG0Qm/nZ/1KDHc+y6FpnZ/apsgh+G6t15vefU0zp3WSpTMIdXRUsNl/7RSuw==",
+      "cpu": [
+        "ia32"
+      ],
+      "optional": true,
+      "os": [
+        "win32"
+      ],
+      "engines": {
+        "node": ">= 10"
+      }
+    },
+    "node_modules/@next/swc-win32-x64-msvc": {
+      "version": "14.1.1",
+      "resolved": "https://registry.npmjs.org/@next/swc-win32-x64-msvc/-/swc-win32-x64-msvc-14.1.1.tgz",
+      "integrity": "sha512-S6K6EHDU5+1KrBDLko7/c1MNy/Ya73pIAmvKeFwsF4RmBFJSO7/7YeD4FnZ4iBdzE69PpQ4sOMU9ORKeNuxe8A==",
+      "cpu": [
+        "x64"
+      ],
+      "optional": true,
+      "os": [
+        "win32"
+      ],
+      "engines": {
+        "node": ">= 10"
+      }
     }
   }
 }

--- a/frontend/src/app/about/page.tsx
+++ b/frontend/src/app/about/page.tsx
@@ -47,7 +47,7 @@ export default function About() {
     }
   }
 
-  const SCHPercent =
+  const SCHPercentage =
     (scraperMetadata.totalSCHProjectsScraped /
       scraperMetadata.totalProjectsScraped) *
     100;
@@ -143,10 +143,10 @@ export default function About() {
           </Card>
           <Card className="flex flex-col justify-between w-[350px] h-[300px]">
             <CardHeader>
-              <CardTitle className="text-center">% Connected to SCH</CardTitle>
+              <CardTitle className="text-center">Connected to SCH</CardTitle>
             </CardHeader>
             <CardContent className="flex h-full justify-center items-center">
-              <h1 className="text-7xl">{SCHPercent.toFixed(1)}%</h1>
+              <h1 className="text-7xl">{SCHPercentage.toFixed(1)}%</h1>
             </CardContent>
           </Card>
           <Card className="flex flex-col w-[350px] h-[300px]">

--- a/frontend/src/app/about/page.tsx
+++ b/frontend/src/app/about/page.tsx
@@ -30,22 +30,10 @@ export default function About() {
   const [scraperMetadata, setScraperMetadata] = useState(defaultData); // some default metadata object
 
   useEffect(() => {
-    fetchMetadata();
-  });
-
-  async function fetchMetadata() {
-    try {
-      const res = await fetch("api/metadata");
-      if (res.ok) {
-        const resAsJSON = await res.json();
-        setScraperMetadata(resAsJSON);
-      } else {
-        throw new Error();
-      }
-    } catch (error) {
-      console.log(error);
-    }
-  }
+    fetch("api/metadata")
+      .then((res) => res.json())
+      .then((resAsJson) => setScraperMetadata(resAsJson));
+  }, []);
 
   const SCHPercentage =
     (scraperMetadata.totalSCHProjectsScraped /

--- a/frontend/src/app/about/page.tsx
+++ b/frontend/src/app/about/page.tsx
@@ -1,5 +1,7 @@
 "use client";
+import { useEffect, useState } from "react";
 import { Button } from "@/components/ui/button";
+
 import {
   Card,
   CardContent,
@@ -13,10 +15,37 @@ const slo_hearings_url =
   "https://www.slocounty.ca.gov/Home/Meetings-Calendar.aspx";
 const ceqa_url = "https://ceqanet.opr.ca.gov/";
 
+const defaultData = {
+  lastRan: "N/A",
+  totalHearingsScraped: 0,
+  totalProjectsScraped: 0,
+  totalSCHProjectsScraped: 0,
+};
+
 export default function About() {
   const handleVisitSite = (url: string) => {
     window.open(url, "_blank");
   };
+
+  const [scraperMetadata, setScraperMetadata] = useState(defaultData); // some default metadata object
+
+  useEffect(() => {
+    fetchMetadata();
+  });
+
+  async function fetchMetadata() {
+    try {
+      const res = await fetch("api/metadata");
+      if (res.ok) {
+        const resAsJSON = await res.json();
+        setScraperMetadata(resAsJSON);
+      } else {
+        throw new Error();
+      }
+    } catch (error) {
+      console.log(error);
+    }
+  }
 
   return (
     <div className="flex flex-col w-full gap-10">
@@ -102,7 +131,9 @@ export default function About() {
               <CardTitle className="text-center">Total Projects</CardTitle>
             </CardHeader>
             <CardContent className="flex h-full justify-center items-center">
-              <h1 className="text-7xl">--</h1>
+              <h1 className="text-7xl">
+                {scraperMetadata.totalProjectsScraped}
+              </h1>
             </CardContent>
           </Card>
           <Card className="flex flex-col justify-between w-[350px] h-[300px]">
@@ -110,7 +141,10 @@ export default function About() {
               <CardTitle className="text-center">% Connected to SCH</CardTitle>
             </CardHeader>
             <CardContent className="flex h-full justify-center items-center">
-              <h1 className="text-7xl">--</h1>
+              <h1 className="text-7xl">
+                {scraperMetadata.totalSCHProjectsScraped /
+                  scraperMetadata.totalProjectsScraped}
+              </h1>
             </CardContent>
           </Card>
           <Card className="flex flex-col w-[350px] h-[300px]">
@@ -118,7 +152,9 @@ export default function About() {
               <CardTitle className="text-center">Total Hearings</CardTitle>
             </CardHeader>
             <CardContent className="flex h-full justify-center items-center">
-              <h1 className="text-7xl">--</h1>
+              <h1 className="text-7xl">
+                {scraperMetadata.totalHearingsScraped}
+              </h1>
             </CardContent>
           </Card>
         </div>

--- a/frontend/src/app/about/page.tsx
+++ b/frontend/src/app/about/page.tsx
@@ -47,6 +47,11 @@ export default function About() {
     }
   }
 
+  const SCHPercent =
+    (scraperMetadata.totalSCHProjectsScraped /
+      scraperMetadata.totalProjectsScraped) *
+    100;
+
   return (
     <div className="flex flex-col w-full gap-10">
       <div className="flex flex-col bg-primary-foreground rounded-lg w-full items-center justify-center py-5 px-20 gap-5">
@@ -141,10 +146,7 @@ export default function About() {
               <CardTitle className="text-center">% Connected to SCH</CardTitle>
             </CardHeader>
             <CardContent className="flex h-full justify-center items-center">
-              <h1 className="text-7xl">
-                {scraperMetadata.totalSCHProjectsScraped /
-                  scraperMetadata.totalProjectsScraped}
-              </h1>
+              <h1 className="text-7xl">{SCHPercent.toFixed(1)}%</h1>
             </CardContent>
           </Card>
           <Card className="flex flex-col w-[350px] h-[300px]">

--- a/frontend/src/app/api/metadata/route.ts
+++ b/frontend/src/app/api/metadata/route.ts
@@ -8,20 +8,6 @@ export async function GET(req: Request) {
     const metadata = await scraperMetadata.findOne().orFail();
     return NextResponse.json(metadata);
   } catch (error) {
-    return NextResponse.json("Failed to fetch run date", { status: 404 });
-  }
-}
-
-export async function POST(req: Request) {
-  await connectDB();
-  try {
-    const metadata = await scraperMetadata.findOneAndUpdate(
-      {},
-      { date_run: new Date() },
-      { upsert: true, new: true }, // Return the updated document
-    );
-    return NextResponse.json(metadata);
-  } catch (error) {
-    return NextResponse.json("Failed to update metadata.", { status: 500 });
+    return NextResponse.json("Failed to fetch metadata");
   }
 }

--- a/frontend/src/app/api/metadata/route.ts
+++ b/frontend/src/app/api/metadata/route.ts
@@ -1,0 +1,27 @@
+import connectDB from "@/database/db";
+import scraperMetadata from "@/database/metadataSchema";
+import { NextResponse } from "next/server";
+
+export async function GET(req: Request) {
+  await connectDB();
+  try {
+    const metadata = await scraperMetadata.findOne().orFail();
+    return NextResponse.json(metadata);
+  } catch (error) {
+    return NextResponse.json("Failed to fetch run date", { status: 404 });
+  }
+}
+
+export async function POST(req: Request) {
+  await connectDB();
+  try {
+    const metadata = await scraperMetadata.findOneAndUpdate(
+      {},
+      { date_run: new Date() },
+      { upsert: true, new: true }, // Return the updated document
+    );
+    return NextResponse.json(metadata);
+  } catch (error) {
+    return NextResponse.json("Failed to update metadata.", { status: 500 });
+  }
+}

--- a/frontend/src/components/scrapeButton.tsx
+++ b/frontend/src/components/scrapeButton.tsx
@@ -14,20 +14,10 @@ export default function ScrapeButton() {
     fetchMetadata();
   }, []);
 
-  const fetchMetadata = async () => {
-    try {
-      const res = await fetch("http://localhost:3000/api/metadata", {
-        method: "GET",
-      });
-      if (res.ok) {
-        const metadata = await res.json();
-        setDateRun(metadata.lastRan);
-      } else {
-        throw new Error("GET");
-      }
-    } catch (error) {
-      console.error("Failed to fetch run date", error);
-    }
+  const fetchMetadata = () => {
+    fetch("api/metadata")
+      .then((res) => res.json())
+      .then((resAsJson) => setDateRun(resAsJson.lastRan));
   };
 
   const handleScrape = async () => {

--- a/frontend/src/components/scrapeButton.tsx
+++ b/frontend/src/components/scrapeButton.tsx
@@ -1,5 +1,5 @@
 "use client";
-import React from "react";
+import React, { useEffect } from "react";
 import { Button } from "@/components/ui/button";
 import { useState } from "react";
 import { FiCommand } from "react-icons/fi";
@@ -7,15 +7,49 @@ import "@/styles/globals.css";
 
 export default function ScrapeButton() {
   const [loading, setLoading] = useState(false);
+  const [dateRun, setDateRun] = useState("Never");
+
+  // fetches metadata once, at the beginning
+  useEffect(() => {
+    fetchMetadata();
+  }, []);
+
+  const fetchMetadata = async () => {
+    try {
+      const res = await fetch("api/metadata", { method: "GET" });
+      if (res.ok) {
+        const metadata = await res.json();
+        setDateRun(metadata.date_run);
+      } else {
+        throw new Error("GET");
+      }
+    } catch (error) {
+      console.error("Failed to fetch run date", error);
+    }
+  };
+
+  const setMetadata = async () => {
+    try {
+      const res = await fetch("api/metadata", { method: "POST" });
+      if (!res.ok) {
+        throw new Error("POST");
+      }
+    } catch (error) {
+      console.error("Failed to update run date", error);
+    }
+  };
 
   const handleScrape = async () => {
     setLoading(true);
-
+    await setMetadata();
     try {
       const response = await fetch("http://localhost:8000/slo_county/hearings");
       if (!response.ok) {
         throw new Error("Failed to fetch data");
       }
+
+      // update button's last run time
+      await setMetadata();
 
       // data["current hearings"] stores an array of the links from the hearings route
       const data = await response.json();
@@ -26,21 +60,39 @@ export default function ScrapeButton() {
 
     setTimeout(() => {
       setLoading(false);
+
+      // get latest button run time
+      fetchMetadata();
     }, 3000);
-    console.log("change to scrape");
+    //console.log("change to scrape");
   };
+
   return (
-    <Button
-      onClick={handleScrape}
-      disabled={loading}
-      className="bg-secondary"
-      style={{ width: "200px" }}
-    >
-      {loading ? (
-        <FiCommand color="white" className="loading-icon" />
-      ) : (
-        "Update table"
+    <div>
+      <Button
+        onClick={handleScrape}
+        disabled={loading}
+        className="bg-secondary"
+        style={{ width: "200px" }}
+      >
+        {loading ? (
+          <FiCommand color="white" className="loading-icon" />
+        ) : (
+          "Update table"
+        )}
+      </Button>
+      {dateRun && (
+        <p style={{ color: "grey", marginTop: "10px" }}>
+          Last run:{" "}
+          {new Date(dateRun).toLocaleString("en-US", {
+            month: "long",
+            day: "numeric",
+            hour: "numeric",
+            minute: "numeric",
+            hour12: true,
+          })}
+        </p>
       )}
-    </Button>
+    </div>
   );
 }

--- a/frontend/src/components/scrapeButton.tsx
+++ b/frontend/src/components/scrapeButton.tsx
@@ -19,7 +19,7 @@ export default function ScrapeButton() {
       const res = await fetch("api/metadata", { method: "GET" });
       if (res.ok) {
         const metadata = await res.json();
-        setDateRun(metadata.date_run);
+        setDateRun(metadata.lastRan);
       } else {
         throw new Error("GET");
       }
@@ -28,28 +28,13 @@ export default function ScrapeButton() {
     }
   };
 
-  const setMetadata = async () => {
-    try {
-      const res = await fetch("api/metadata", { method: "POST" });
-      if (!res.ok) {
-        throw new Error("POST");
-      }
-    } catch (error) {
-      console.error("Failed to update run date", error);
-    }
-  };
-
   const handleScrape = async () => {
     setLoading(true);
-    await setMetadata();
     try {
       const response = await fetch("http://localhost:8000/slo_county/hearings");
       if (!response.ok) {
         throw new Error("Failed to fetch data");
       }
-
-      // update button's last run time
-      await setMetadata();
 
       // data["current hearings"] stores an array of the links from the hearings route
       const data = await response.json();

--- a/frontend/src/components/scrapeButton.tsx
+++ b/frontend/src/components/scrapeButton.tsx
@@ -16,7 +16,9 @@ export default function ScrapeButton() {
 
   const fetchMetadata = async () => {
     try {
-      const res = await fetch("api/metadata", { method: "GET" });
+      const res = await fetch("http://localhost:3000/api/metadata", {
+        method: "GET",
+      });
       if (res.ok) {
         const metadata = await res.json();
         setDateRun(metadata.lastRan);

--- a/frontend/src/database/metadataSchema.ts
+++ b/frontend/src/database/metadataSchema.ts
@@ -1,7 +1,10 @@
 import mongoose, { Schema } from "mongoose";
 
 const metadataSchema = new Schema({
-  date_run: Date,
+  lastRan: Date,
+  totalHearingsScraped: Number,
+  totalProjectsScraped: Number,
+  totalSCHProjectsScraped: Number,
 });
 
 export default mongoose.models.scraperMetadata ||

--- a/frontend/src/database/metadataSchema.ts
+++ b/frontend/src/database/metadataSchema.ts
@@ -1,0 +1,8 @@
+import mongoose, { Schema } from "mongoose";
+
+const metadataSchema = new Schema({
+  date_run: Date,
+});
+
+export default mongoose.models.scraperMetadata ||
+  mongoose.model("scraperMetadata", metadataSchema);


### PR DESCRIPTION
## Developer: James

Closes #80 #96  #102 

### Pull Request Summary

Add web scraper metadata that displays the last run date below the scrape button and also displays info about the number of projects scraper on the About page.

### Modifications

New database collection test/scrapermetadatas
New schema for metadata in components/database/metadataSchema
New update_metadata function in utils/slo_county
New GET endpoint for metadata in app/api/metadata/route.ts
ScrapeButton and About page now use metadata endpoint

### Testing Considerations

Tested basic functionality.
A potential issue where the total number of hearings is incremented every time the scraper button is run. This number is incremented by an argument passed to the update_metadata function from the slo_county route. Check if the number passed is correct.
An issue where the 'projects' collection will need to be reset and the scraper run so initial values in metadata collection are correct.
A potential issue where handleScrape in components/scrapeButton uses async/await in a client component?

### Pull Request Checklist

- [ ] Code is neat, readable, and works
- [ ] Comments are appropriate
- [ ] The commit messages follows our [guidelines](https://h4i.notion.site/Conventional-Commits-593452ad1179489399ad3bd696ef772a)
- [ ] The developer name is specified
- [ ] The summary is completed
- [ ] Assign reviewers

### Screenshots/Screencast

{put screenshots of your change, or even better a screencast displaying the functionality}
