### PR TITLE
feat: table header for project count

### DIFF
--- a/frontend/src/components/proposalTable.tsx
+++ b/frontend/src/components/proposalTable.tsx
@@ -337,12 +337,14 @@ async function getData(): Promise<IProject[]> {
 
 export function ProposalTable() {
   const [tableData, setTableData] = useState<IProject[]>([]);
+  const [numProjects, setNumProjects] = useState(0);
 
   useEffect(() => {
     const fetchData = async () => {
       try {
         const proposals = await getData();
         setTableData(proposals);
+        setNumProjects(proposals.length);
       } catch (error) {
         console.error("Error fetching proposals", error);
       }
@@ -351,7 +353,10 @@ export function ProposalTable() {
   }, []);
 
   return (
-    <div className="container mx-auto py-10">
+    <div className="container mx-auto py-5">
+      <div className="text-xl font-bold">
+        San Luis Obispo County ({numProjects})
+      </div>
       <DataTable columns={columns} data={tableData} />
     </div>
   );


### PR DESCRIPTION
## Developer: Eeshan Walia

Closes #130 

### Pull Request Summary

Created a table header to display the county and number of projects available. 

### Modifications

Modified useEffect in proposalTable.tsx to store the number of projects every time the scraping is triggered. 

### Testing Considerations

{list out what you have tested and what the reviewer should verify}

### Pull Request Checklist

- [ x] Code is neat, readable, and works
- [ x] Comments are appropriate
- [ x] The commit messages follows our [guidelines](https://h4i.notion.site/Conventional-Commits-593452ad1179489399ad3bd696ef772a)
- [ x] The developer name is specified
- [x ] The summary is completed
- [x ] Assign reviewers

### Screenshots/Screencast

{put screenshots of your change, or even better a screencast displaying the functionality}
